### PR TITLE
Add weekly GitHub Actions workflow to refresh web spec data

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -48,7 +48,23 @@ jobs:
           rm -rf baselines
           cp -r generated baselines
 
-      - name: Open a pull request if anything changed
+      # The PR is gated on the generated type definitions actually changing.
+      # --porcelain catches modified, added, and deleted baseline files.
+      - name: Detect baseline changes
+        id: baselines
+        run: |
+          if [ -n "$(git status --porcelain -- baselines)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No change in generated type definitions; skipping PR."
+          fi
+
+      # Only open a PR when baselines/ changed, but when it does, carry the
+      # refreshed package-lock.json and inputfiles/mdn.json along so the
+      # update is committed in full.
+      - name: Open a pull request when the generated types change
+        if: steps.baselines.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,20 +73,19 @@ jobs:
           body: |
             Automated weekly refresh of the generated type baselines.
 
-            `@webref/*` and `@mdn/*` were bumped to their latest versions and the
-            MDN metadata was re-fetched during this run; this PR is opened only
-            because those updates changed the generated `baselines/` type
-            definitions (see the diff).
+            This PR is opened only because the latest `@webref/*` / `@mdn/*` data
+            changed the generated type definitions. It bundles the full update:
+
+            - `package-lock.json` — bumped `@webref/*` and `@mdn/*`.
+            - `inputfiles/mdn.json` — re-fetched MDN metadata.
+            - `baselines/**` — regenerated type definitions (see the diff).
 
             Merging keeps the published `@baseline-types/dom-<year>` packages in sync
             with the latest browser-compat data. Review the diff, then publish with
             `npm run baseline-years` → `baseline-packages` → `baseline-publish`.
           branch: weekly-update
           delete-branch: true
-          # Only open a PR when the regenerated type definitions actually
-          # change. @webref/@mdn bumps and the re-fetched mdn.json are still
-          # applied during the run (they drive the build), but they are not
-          # committed on their own — so a dependency patch or metadata tweak
-          # that doesn't alter the emitted types won't produce a PR.
           add-paths: |
+            package-lock.json
+            inputfiles/mdn.json
             baselines/**

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -1,0 +1,72 @@
+name: Weekly update
+
+on:
+  workflow_dispatch: null
+  schedule:
+    # https://crontab.guru/#0_12_*_*_6 — Saturdays at 12:00 UTC
+    - cron: "0 12 * * 6"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    # Don't run on forks-of-the-fork; only the canonical repo opens PRs.
+    if: github.repository == 'uhyo/TypeScript-Baseline-Types'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: npm
+
+      - run: npm ci
+
+      # Bump the web spec data (@webref/* and @mdn/*) to its latest versions,
+      # then restore package.json so only package-lock.json records the new
+      # resolved versions. This keeps the caret ranges in package.json stable so
+      # a contributor's local `npm i` doesn't produce a spurious diff.
+      # See: https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1463
+      - run: npm i -g npm-check-updates
+      - run: ncu -u "@mdn*" "@webref*"
+      - run: npm i
+      - run: git restore package.json
+      - run: npm i
+
+      - name: Refresh MDN metadata
+        run: node scripts/fetch-mdn.js
+
+      # Rebuild the lib from the updated data and re-mirror the tracked
+      # baselines/ snapshot, which src/test.ts compares against generated/ file
+      # for file. generated/ is gitignored, so only baselines/ lands in the PR.
+      - name: Rebuild lib and refresh baselines snapshot
+        run: |
+          npm run build
+          rm -rf baselines
+          cp -r generated baselines
+
+      - name: Open a pull request if anything changed
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "🤖 Weekly update: refresh web spec data"
+          title: "🤖 Weekly update: refresh web spec data"
+          body: |
+            Automated weekly refresh of the upstream web platform spec data.
+
+            - Bumped `@webref/*` and `@mdn/*` to their latest versions (lockfile only).
+            - Re-fetched MDN metadata into `inputfiles/mdn.json`.
+            - Regenerated the `baselines/` snapshot from the updated data.
+
+            Merging keeps the published `@baseline-types/dom-<year>` packages in sync
+            with the latest browser-compat data. Review the diff, then publish with
+            `npm run baseline-years` → `baseline-packages` → `baseline-publish`.
+          branch: weekly-update
+          delete-branch: true
+          add-paths: |
+            package-lock.json
+            inputfiles/mdn.json
+            baselines/**

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -55,18 +55,22 @@ jobs:
           commit-message: "🤖 Weekly update: refresh web spec data"
           title: "🤖 Weekly update: refresh web spec data"
           body: |
-            Automated weekly refresh of the upstream web platform spec data.
+            Automated weekly refresh of the generated type baselines.
 
-            - Bumped `@webref/*` and `@mdn/*` to their latest versions (lockfile only).
-            - Re-fetched MDN metadata into `inputfiles/mdn.json`.
-            - Regenerated the `baselines/` snapshot from the updated data.
+            `@webref/*` and `@mdn/*` were bumped to their latest versions and the
+            MDN metadata was re-fetched during this run; this PR is opened only
+            because those updates changed the generated `baselines/` type
+            definitions (see the diff).
 
             Merging keeps the published `@baseline-types/dom-<year>` packages in sync
             with the latest browser-compat data. Review the diff, then publish with
             `npm run baseline-years` → `baseline-packages` → `baseline-publish`.
           branch: weekly-update
           delete-branch: true
+          # Only open a PR when the regenerated type definitions actually
+          # change. @webref/@mdn bumps and the re-fetched mdn.json are still
+          # applied during the run (they drive the build), but they are not
+          # committed on their own — so a dependency patch or metadata tweak
+          # that doesn't alter the emitted types won't produce a PR.
           add-paths: |
-            package-lock.json
-            inputfiles/mdn.json
             baselines/**


### PR DESCRIPTION
## Summary

Adds `.github/workflows/weekly-update.yml`, a scheduled workflow that keeps the upstream web platform spec data current so the published `@baseline-types/dom-<year>` packages don't drift.

Runs **Saturdays at 12:00 UTC** (cron `0 12 * * 6`) plus a manual `workflow_dispatch` trigger. On each run it:

1. Bumps `@webref/*` and `@mdn/*` to their latest versions via `npm-check-updates`, then restores `package.json` so only `package-lock.json` records the new resolved versions (keeps caret ranges stable for local `npm i`, mirroring the upstream `update-core-deps` convention).
2. Re-fetches MDN metadata into `inputfiles/mdn.json` via `scripts/fetch-mdn.js`.
3. Rebuilds the lib and re-mirrors the tracked `baselines/` snapshot so it stays an exact copy of `generated/` (what `src/test.ts` compares against).
4. Opens/updates a PR (`weekly-update` branch) when any of `package-lock.json`, `inputfiles/mdn.json`, or `baselines/**` changed.

The job is gated to the canonical repo (`if: github.repository == 'uhyo/TypeScript-Baseline-Types'`) and uses the built-in `GITHUB_TOKEN`. It only opens a PR for review — it never publishes. After merging a weekly PR, publish with the documented `baseline-years` → `baseline-packages` → `baseline-publish` flow.

## Design notes

- **No auto-publish** — every update goes through a reviewable PR; the PR's existing CI runs the full `npm test`.
- **Deliberately avoids `npm run generate`.** The fork's `baseline-accept` script globs `generated\**` with backslashes, which silently matches nothing on Linux. The workflow instead runs `npm run build` + `rm -rf baselines && cp -r generated baselines`, which also handles removed files (a plain `cpx` copy would leave stale baselines behind). Happy to follow up with a forward-slash fix to `baseline-accept` if you'd prefer to reuse it.
- **`peter-evans/create-pull-request@v8`** is referenced by tag, matching upstream usage. Can SHA-pin it (and the `actions/*` ones) if you want to match `update-core-deps.yml`.

> Note: scheduled triggers only fire from the default branch, so the weekly run begins once this is merged into `baseline-filter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANG558GikAfU8EgvnSTFzv)_