### PR TITLE
Auto-release baseline packages when the weekly-update PR is merged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ on:
   workflow_dispatch: null
 
 permissions:
-  contents: write
+  contents: write # create tags + GitHub Releases
+  id-token: write # OIDC trusted publishing to npm (no token needed)
 
 jobs:
   release:
@@ -30,6 +31,10 @@ jobs:
 
       - run: npm ci
 
+      # OIDC trusted publishing needs npm >= 11.5.1; the npm bundled with lts/*
+      # may be older, so pin to latest before publishing.
+      - run: npm i -g npm@latest
+
       # Rebuild the per-year cuts from the tracked baselines/ snapshot, then
       # assemble the @baseline-types/dom-<year> package folders under
       # deploy/generated/. Both default to DEFAULT_YEARS, so no year list to
@@ -40,13 +45,15 @@ jobs:
       # Publish only the packages whose .d.ts changed vs npm `latest`. The
       # script writes the packages it actually published to $GITHUB_OUTPUT as
       # `published` (a JSON array; `[]` when nothing changed).
+      #
+      # No npm token: `id-token: write` lets `npm publish` exchange a short-lived
+      # OIDC credential with npm, and provenance is attached automatically. Each
+      # @baseline-types/dom-<year> package must have a trusted publisher
+      # configured in its npm settings pointing at this repo + this workflow
+      # (.github/workflows/release.yml). See the README for the one-time setup.
       - name: Publish changed packages to npm
         id: publish
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm run baseline-publish -- --publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: npm run baseline-publish -- --publish
 
       # Tag each freshly published package and cut a GitHub Release, matching the
       # @baseline-types/dom-<year>@<version> convention from the README.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release baseline packages
+
+# Auto-publishes the @baseline-types/dom-<year> packages whenever the tracked
+# baselines/ snapshot changes on the default branch — i.e. when the weekly
+# update PR (or any baselines/ change) is merged. Publishing is idempotent:
+# publishBaselineTypesPackages.js only pushes a package whose .d.ts differs from
+# the current npm `latest`, so a no-op merge republishes nothing.
+on:
+  push:
+    branches: [baseline-filter]
+    paths:
+      - "baselines/**"
+  workflow_dispatch: null
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # Only the canonical repo publishes; forks-of-the-fork stay quiet.
+    if: github.repository == 'uhyo/TypeScript-Baseline-Types'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: npm
+
+      - run: npm ci
+
+      # Rebuild the per-year cuts from the tracked baselines/ snapshot, then
+      # assemble the @baseline-types/dom-<year> package folders under
+      # deploy/generated/. Both default to DEFAULT_YEARS, so no year list to
+      # keep in sync here.
+      - run: npm run baseline-years
+      - run: npm run baseline-packages
+
+      # Publish only the packages whose .d.ts changed vs npm `latest`. The
+      # script writes the packages it actually published to $GITHUB_OUTPUT as
+      # `published` (a JSON array; `[]` when nothing changed).
+      - name: Publish changed packages to npm
+        id: publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          npm run baseline-publish -- --publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+      # Tag each freshly published package and cut a GitHub Release, matching the
+      # @baseline-types/dom-<year>@<version> convention from the README.
+      - name: Tag and release published packages
+        if: steps.publish.outputs.published != '' && steps.publish.outputs.published != '[]'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED: ${{ steps.publish.outputs.published }}
+        run: |
+          echo "$PUBLISHED" | jq -c '.[]' | while read -r pkg; do
+            name=$(echo "$pkg" | jq -r '.name')
+            version=$(echo "$pkg" | jq -r '.version')
+            tag="${name}@${version}"
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "Release $tag already exists; skipping."
+              continue
+            fi
+            echo "Creating release $tag"
+            gh release create "$tag" \
+              --target "$GITHUB_SHA" \
+              --title "$tag" \
+              --notes "Automated release of \`${name}@${version}\`. Published to npm: https://www.npmjs.com/package/${name}/v/${version}"
+          done

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -81,8 +81,11 @@ jobs:
             - `baselines/**` — regenerated type definitions (see the diff).
 
             Merging keeps the published `@baseline-types/dom-<year>` packages in sync
-            with the latest browser-compat data. Review the diff, then publish with
-            `npm run baseline-years` → `baseline-packages` → `baseline-publish`.
+            with the latest browser-compat data. Once this PR is merged, the
+            **Release baseline packages** workflow automatically rebuilds the cuts and
+            publishes any `@baseline-types/dom-<year>` package whose types changed
+            (and cuts a GitHub Release per published package). No manual publish step
+            is needed — just review the diff and merge.
           branch: weekly-update
           delete-branch: true
           add-paths: |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Notes:
 
 ## Building and publishing
 
+> **Releases are automated.** Merging a change to `baselines/**` on the default
+> branch (e.g. the weekly update PR) triggers the **Release baseline packages**
+> workflow (`.github/workflows/release.yml`), which rebuilds the cuts, publishes
+> any `@baseline-types/dom-<year>` package whose `.d.ts` changed, and cuts a
+> GitHub Release per published package. The steps below are the equivalent manual
+> flow, useful for local dry runs.
+
 ```sh
 npm install
 
@@ -95,8 +102,10 @@ or the worker scopes there as needed.
   released together. Record changes in [`CHANGELOG.md`](./CHANGELOG.md).
 - `baseline-publish` only pushes packages whose `.d.ts` differs from the current
   npm `latest`, so re-running after a no-op data refresh is safe.
-- Tag each release per package, e.g. `git tag -a "@baseline-types/dom-2024@0.0.2"`,
-  matching the upstream `@types/<pkg>@<version>` tag convention.
+- The release workflow tags each published package and cuts a matching GitHub
+  Release named `@baseline-types/dom-<year>@<version>` (matching the upstream
+  `@types/<pkg>@<version>` convention). For a manual publish, create the tag
+  yourself, e.g. `git tag -a "@baseline-types/dom-2024@0.0.2"`.
 
 ## Keeping in sync with upstream
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Notes:
 > any `@baseline-types/dom-<year>` package whose `.d.ts` changed, and cuts a
 > GitHub Release per published package. The steps below are the equivalent manual
 > flow, useful for local dry runs.
+>
+> The workflow publishes via npm's [trusted publishing](https://docs.npmjs.com/trusted-publishers)
+> (OIDC) — no `NPM_TOKEN` secret is stored. One-time setup per package: on
+> npmjs.com, open each `@baseline-types/dom-<year>` package's **Settings →
+> Trusted Publisher**, add a GitHub Actions publisher pointing at
+> `uhyo/TypeScript-Baseline-Types` with workflow `release.yml`. A brand-new
+> package can't be configured until it exists, so publish its first version
+> manually (the manual flow below), then add the trusted publisher.
 
 ```sh
 npm install

--- a/deploy/publishBaselineTypesPackages.js
+++ b/deploy/publishBaselineTypesPackages.js
@@ -26,6 +26,8 @@ const generatedDir = new URL("generated/", import.meta.url);
 const packages = baselinePackages(wantedYears);
 
 const uploaded = [];
+/** @type {Array<{name: string, version: string}>} Packages actually published. */
+const published = [];
 
 for (const pkg of packages) {
   const folderName = pkg.name.replace("@", "").replace("/", "-");
@@ -78,6 +80,7 @@ for (const pkg of packages) {
       process.exit(publish.status);
     }
     uploaded.push(`${pkg.name}@${pkgJSON.version}`);
+    published.push({ name: pkg.name, version: pkgJSON.version });
   } else {
     console.log(
       ` - would run: npm publish --access public  (in ${fileURLToPath(packageDir)})`,
@@ -96,6 +99,16 @@ if (uploaded.length) {
   );
 } else {
   console.log("Nothing to publish.");
+}
+
+// When run from CI (e.g. the auto-release workflow), expose the set of packages
+// that were actually published as a step output so a later step can tag them
+// and cut GitHub Releases. Only real publishes are reported, never dry-runs.
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `published=${JSON.stringify(published)}\n`,
+  );
 }
 
 /**

--- a/scripts/generate-baseline-years.js
+++ b/scripts/generate-baseline-years.js
@@ -1,23 +1,23 @@
 import { execFileSync } from "node:child_process";
 import { cp, mkdir, rm } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { DEFAULT_YEARS } from "../deploy/createBaselineTypesPackages.js";
 
 // Generates a Baseline-year-cut copy of the lib for each given year by running
 // the build with BASELINE_YEAR set and copying generated/ to baseline-<year>/.
 //
 //   node ./scripts/generate-baseline-years.js 2020 2021 2022 2023 2024
 //   npm run baseline-years -- 2024
+//
+// With no years given, falls back to DEFAULT_YEARS (the same default set
+// createBaselineTypesPackages.js / publishBaselineTypesPackages.js use), so the
+// release pipeline can run `npm run baseline-years` with no arguments.
 
 const root = new URL("../", import.meta.url);
 const generated = new URL("generated/", root);
 
-const years = process.argv.slice(2);
-if (years.length === 0) {
-  console.error(
-    "Usage: node ./scripts/generate-baseline-years.js <year> [<year> ...]",
-  );
-  process.exit(1);
-}
+const args = process.argv.slice(2);
+const years = args.length ? args : DEFAULT_YEARS;
 
 for (const year of years) {
   if (!/^\d{4}$/.test(year)) {


### PR DESCRIPTION
Add a Release baseline packages workflow that publishes the
@baseline-types/dom-<year> packages whenever baselines/** changes on the
default branch (i.e. when the weekly update PR is merged). It rebuilds the
per-year cuts, assembles the package folders, publishes only packages whose
.d.ts differs from npm latest, then tags each published package and cuts a
matching GitHub Release.

Supporting changes:
- publishBaselineTypesPackages.js: emit the list of packages actually
  published to $GITHUB_OUTPUT so the workflow can tag/release them.
- generate-baseline-years.js: default to DEFAULT_YEARS when no years are
  given, so the workflow needn't hardcode the year list.
- Update weekly-update PR body and README to document the automated release.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LkdL74Yxmhd9Tgm9Qi6cG7