### PR TITLE
Show which packages the weekly update will republish

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -48,8 +48,10 @@ jobs:
           rm -rf baselines
           cp -r generated baselines
 
-      # The PR is gated on the generated type definitions actually changing.
-      # --porcelain catches modified, added, and deleted baseline files.
+      # First gate: skip everything unless the tracked baselines/ snapshot moved.
+      # This is a cheap pre-filter (avoids building four year-cuts for nothing);
+      # the authoritative gate is the per-package check below. --porcelain
+      # catches modified, added, and deleted baseline files.
       - name: Detect baseline changes
         id: baselines
         run: |
@@ -60,13 +62,14 @@ jobs:
             echo "No change in generated type definitions; skipping PR."
           fi
 
-      # The raw baselines/ diff is the full latest cut, so it doesn't show which
-      # per-year @baseline-types/dom-<year> packages a merge will actually
-      # republish. Reproduce the release pipeline's dry run here: build the
-      # per-year cuts and packages, then diff each one against its npm `latest`.
-      # publishBaselineTypesPackages.js (without --publish) writes the changed
-      # packages to $GITHUB_OUTPUT as `would_publish` (a JSON array; `[]` when
-      # the data moved but no published year cut was affected).
+      # Second gate: the raw baselines/ diff is the full latest cut, so a change
+      # there doesn't mean any published per-year @baseline-types/dom-<year>
+      # package actually changed (e.g. an API newer than the latest packaged year
+      # shows in the latest cut but in no year cut). Reproduce the release
+      # pipeline's dry run — build the per-year cuts and packages, then diff each
+      # one against its npm `latest`. publishBaselineTypesPackages.js (without
+      # --publish) writes the changed packages to $GITHUB_OUTPUT as
+      # `would_publish` (a JSON array; `[]` when no published year cut moved).
       - name: Compute which packages this update will republish
         id: affected
         if: steps.baselines.outputs.changed == 'true'
@@ -75,10 +78,17 @@ jobs:
           npm run baseline-packages
           npm run baseline-publish
 
+      # Make the "changed data, but no package impact" outcome explicit in the
+      # logs — this is the case the package-level gate now suppresses.
+      - name: Note when no published package is affected
+        if: steps.baselines.outputs.changed == 'true' && (steps.affected.outputs.would_publish == '' || steps.affected.outputs.would_publish == '[]')
+        run: echo "Baselines changed but no published @baseline-types/dom-<year> package was affected; skipping PR."
+
       # Render the PR body, turning the would_publish list into a checklist so the
-      # package-level impact is visible at a glance without reading the diff.
+      # package-level impact is visible at a glance without reading the diff. Runs
+      # only when at least one package is affected (same gate as the PR step).
       - name: Render PR body
-        if: steps.baselines.outputs.changed == 'true'
+        if: steps.affected.outputs.would_publish != '' && steps.affected.outputs.would_publish != '[]'
         env:
           WOULD_PUBLISH: ${{ steps.affected.outputs.would_publish }}
         run: |
@@ -86,7 +96,7 @@ jobs:
             echo "Automated weekly refresh of the generated type baselines."
             echo ""
             echo "This PR is opened only because the latest \`@webref/*\` / \`@mdn/*\` data"
-            echo "changed the generated type definitions. It bundles the full update:"
+            echo "changed at least one published type cut. It bundles the full update:"
             echo ""
             echo "- \`package-lock.json\` — bumped \`@webref/*\` and \`@mdn/*\`."
             echo "- \`inputfiles/mdn.json\` — re-fetched MDN metadata."
@@ -97,11 +107,7 @@ jobs:
             echo "Computed by diffing each per-year cut against its current npm \`latest\`"
             echo "(predicted next version shown):"
             echo ""
-            if [ "$(echo "$WOULD_PUBLISH" | jq 'length')" -eq 0 ]; then
-              echo "_None — the data changed but no published \`@baseline-types/dom-<year>\` cut was affected, so the release workflow will publish nothing._"
-            else
-              echo "$WOULD_PUBLISH" | jq -r '.[] | "- [ ] `\(.name)` → `\(.version)`"'
-            fi
+            echo "$WOULD_PUBLISH" | jq -r '.[] | "- [ ] `\(.name)` → `\(.version)`"'
             echo ""
             echo "Merging keeps the published \`@baseline-types/dom-<year>\` packages in sync"
             echo "with the latest browser-compat data. Once this PR is merged, the"
@@ -111,11 +117,11 @@ jobs:
             echo "is needed — just review the diff and merge."
           } > pr-body.md
 
-      # Only open a PR when baselines/ changed, but when it does, carry the
-      # refreshed package-lock.json and inputfiles/mdn.json along so the
-      # update is committed in full.
-      - name: Open a pull request when the generated types change
-        if: steps.baselines.outputs.changed == 'true'
+      # Open a PR only when at least one published package would change, and when
+      # it does, carry the refreshed package-lock.json and inputfiles/mdn.json
+      # along so the update is committed in full.
+      - name: Open a pull request when a published package changes
+        if: steps.affected.outputs.would_publish != '' && steps.affected.outputs.would_publish != '[]'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -60,6 +60,57 @@ jobs:
             echo "No change in generated type definitions; skipping PR."
           fi
 
+      # The raw baselines/ diff is the full latest cut, so it doesn't show which
+      # per-year @baseline-types/dom-<year> packages a merge will actually
+      # republish. Reproduce the release pipeline's dry run here: build the
+      # per-year cuts and packages, then diff each one against its npm `latest`.
+      # publishBaselineTypesPackages.js (without --publish) writes the changed
+      # packages to $GITHUB_OUTPUT as `would_publish` (a JSON array; `[]` when
+      # the data moved but no published year cut was affected).
+      - name: Compute which packages this update will republish
+        id: affected
+        if: steps.baselines.outputs.changed == 'true'
+        run: |
+          npm run baseline-years
+          npm run baseline-packages
+          npm run baseline-publish
+
+      # Render the PR body, turning the would_publish list into a checklist so the
+      # package-level impact is visible at a glance without reading the diff.
+      - name: Render PR body
+        if: steps.baselines.outputs.changed == 'true'
+        env:
+          WOULD_PUBLISH: ${{ steps.affected.outputs.would_publish }}
+        run: |
+          {
+            echo "Automated weekly refresh of the generated type baselines."
+            echo ""
+            echo "This PR is opened only because the latest \`@webref/*\` / \`@mdn/*\` data"
+            echo "changed the generated type definitions. It bundles the full update:"
+            echo ""
+            echo "- \`package-lock.json\` — bumped \`@webref/*\` and \`@mdn/*\`."
+            echo "- \`inputfiles/mdn.json\` — re-fetched MDN metadata."
+            echo "- \`baselines/**\` — regenerated type definitions (see the diff)."
+            echo ""
+            echo "### Packages this merge will republish"
+            echo ""
+            echo "Computed by diffing each per-year cut against its current npm \`latest\`"
+            echo "(predicted next version shown):"
+            echo ""
+            if [ "$(echo "$WOULD_PUBLISH" | jq 'length')" -eq 0 ]; then
+              echo "_None — the data changed but no published \`@baseline-types/dom-<year>\` cut was affected, so the release workflow will publish nothing._"
+            else
+              echo "$WOULD_PUBLISH" | jq -r '.[] | "- [ ] `\(.name)` → `\(.version)`"'
+            fi
+            echo ""
+            echo "Merging keeps the published \`@baseline-types/dom-<year>\` packages in sync"
+            echo "with the latest browser-compat data. Once this PR is merged, the"
+            echo "**Release baseline packages** workflow automatically rebuilds the cuts and"
+            echo "publishes any \`@baseline-types/dom-<year>\` package whose types changed"
+            echo "(and cuts a GitHub Release per published package). No manual publish step"
+            echo "is needed — just review the diff and merge."
+          } > pr-body.md
+
       # Only open a PR when baselines/ changed, but when it does, carry the
       # refreshed package-lock.json and inputfiles/mdn.json along so the
       # update is committed in full.
@@ -70,22 +121,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "🤖 Weekly update: refresh web spec data"
           title: "🤖 Weekly update: refresh web spec data"
-          body: |
-            Automated weekly refresh of the generated type baselines.
-
-            This PR is opened only because the latest `@webref/*` / `@mdn/*` data
-            changed the generated type definitions. It bundles the full update:
-
-            - `package-lock.json` — bumped `@webref/*` and `@mdn/*`.
-            - `inputfiles/mdn.json` — re-fetched MDN metadata.
-            - `baselines/**` — regenerated type definitions (see the diff).
-
-            Merging keeps the published `@baseline-types/dom-<year>` packages in sync
-            with the latest browser-compat data. Once this PR is merged, the
-            **Release baseline packages** workflow automatically rebuilds the cuts and
-            publishes any `@baseline-types/dom-<year>` package whose types changed
-            (and cuts a GitHub Release per published package). No manual publish step
-            is needed — just review the diff and merge.
+          body-path: pr-body.md
           branch: weekly-update
           delete-branch: true
           add-paths: |

--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,6 @@ deploy/generated
 
 # Baseline-year cut output (npm run baseline-years)
 baseline-20*/
+
+# Rendered weekly-update PR body (CI scratch file)
+pr-body.md

--- a/deploy/publishBaselineTypesPackages.js
+++ b/deploy/publishBaselineTypesPackages.js
@@ -28,6 +28,13 @@ const packages = baselinePackages(wantedYears);
 const uploaded = [];
 /** @type {Array<{name: string, version: string}>} Packages actually published. */
 const published = [];
+/**
+ * Every package whose .d.ts differs from npm `latest` — i.e. what *would* be
+ * published. Populated in both dry-run and `--publish` mode so callers (e.g. the
+ * weekly-update workflow) can show the package-level impact before merging.
+ * @type {Array<{name: string, version: string}>}
+ */
+const wouldPublish = [];
 
 for (const pkg of packages) {
   const folderName = pkg.name.replace("@", "").replace("/", "-");
@@ -71,6 +78,8 @@ for (const pkg of packages) {
     continue;
   }
 
+  wouldPublish.push({ name: pkg.name, version: pkgJSON.version });
+
   if (doPublish) {
     const publish = spawnSync("npm", ["publish", "--access", "public"], {
       cwd: fileURLToPath(packageDir),
@@ -101,13 +110,17 @@ if (uploaded.length) {
   console.log("Nothing to publish.");
 }
 
-// When run from CI (e.g. the auto-release workflow), expose the set of packages
-// that were actually published as a step output so a later step can tag them
-// and cut GitHub Releases. Only real publishes are reported, never dry-runs.
+// When run from CI, expose two step outputs:
+//   published     — packages actually published (always [] on a dry-run), used
+//                   by the release workflow to tag + cut GitHub Releases.
+//   would_publish — packages whose .d.ts differs from npm `latest`, populated in
+//                   both modes, used by the weekly-update workflow to show which
+//                   @baseline-types/dom-<year> packages a merge will republish.
 if (process.env.GITHUB_OUTPUT) {
   fs.appendFileSync(
     process.env.GITHUB_OUTPUT,
-    `published=${JSON.stringify(published)}\n`,
+    `published=${JSON.stringify(published)}\n` +
+      `would_publish=${JSON.stringify(wouldPublish)}\n`,
   );
 }
 


### PR DESCRIPTION
The weekly-update PR diff only contains the raw baselines/ snapshot (the
full latest cut), so a reviewer can't tell which per-year
@baseline-types/dom-<year> packages a merge will actually republish: a
data change affects different year cuts depending on when each API
reached Baseline.

Reproduce the release pipeline's dry run in the weekly-update workflow
(baseline-years -> baseline-packages -> baseline-publish without
--publish) and surface the result in the PR body as a checklist. To do
that, publishBaselineTypesPackages.js now also emits a `would_publish`
step output (the changed packages, populated in both dry-run and publish
mode) alongside the existing `published` output.

The rendered body is written to a gitignored pr-body.md and passed via
create-pull-request's body-path; add-paths still keeps it out of the
commit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CvNDuLePhG99sbWEZPyVqD