### PR TITLE
Assign repo owner as reviewer on weekly-update PRs

### DIFF
--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -130,6 +130,9 @@ jobs:
           body-path: pr-body.md
           branch: weekly-update
           delete-branch: true
+          # Assign the repo owner as a reviewer so an automated PR still triggers a
+          # review-request notification (the bot's own PR-opened event doesn't).
+          reviewers: uhyo
           add-paths: |
             package-lock.json
             inputfiles/mdn.json


### PR DESCRIPTION
The weekly-update action's PR is opened by the GITHUB_TOKEN bot, which
doesn't generate a notification for the maintainer. Requesting the repo
owner as a reviewer triggers a review-request notification instead.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XrxsAsTYFoj4mGdfSDn2kD