### PR TITLE
Version @baseline-types packages by release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ noted.
 This file tracks the **packages**, not the upstream generator. See the git history
 for changes to the build pipeline itself.
 
+## Versioning scheme change
+
+Starting with the next release, the packages use a **date-based patch version**:
+`1.0.YYYYMMDD` (e.g. `1.0.20260707`). Previously the patch was incremented by one
+on each release (`0.0.1`, `0.0.2`, …). The major and minor are now fixed at `1.0`
+and the patch records the UTC day each data refresh was cut, so the version
+itself tells you how fresh the Baseline data is.
+
 ## 0.0.2
 
 - **Fix: the cut is now a strict subset of the full lib.** Previously, when

--- a/deploy/createBaselineTypesPackages.js
+++ b/deploy/createBaselineTypesPackages.js
@@ -8,7 +8,6 @@
 
 import fs from "fs";
 import { fileURLToPath } from "url";
-import semver from "semver";
 import pkg from "prettier";
 import path from "path";
 const { format } = pkg;
@@ -149,26 +148,10 @@ async function updatePackageJSON(pkg, packagePath) {
   packageJSON.homepage =
     "https://github.com/uhyo/TypeScript-Baseline-Types#readme";
 
-  // Bump the patch from the latest version on npm, or default to 0.0.1 for the
-  // first publish of this (scope, year).
-  let version = "0.0.1";
-  try {
-    const npmResponse = await fetch(
-      `https://registry.npmjs.org/${packageJSON.name}`,
-    );
-    const npmPackage = await npmResponse.json();
-    const semverMarkers = npmPackage["dist-tags"].latest.split(".");
-    const bumpedVersion = `${semverMarkers[0]}.${semverMarkers[1]}.${
-      Number(semverMarkers[2]) + 1
-    }`;
-    if (semver.gt(bumpedVersion, version)) {
-      version = bumpedVersion;
-    }
-  } catch {
-    // NOOP: first deploy, leaves version at 0.0.1.
-  }
-
-  packageJSON.version = version;
+  // The patch component is the release date (UTC, YYYYMMDD), so every publish is
+  // stamped with the day it was cut — e.g. 1.0.20260707. The major and minor stay
+  // fixed at 1.0; the date-based patch monotonically increases across releases.
+  packageJSON.version = `1.0.${releaseDatePatch()}`;
 
   fs.writeFileSync(
     pkgJSONPath,
@@ -178,6 +161,19 @@ async function updatePackageJSON(pkg, packagePath) {
   );
 
   return packageJSON;
+}
+
+/**
+ * The release date as a YYYYMMDD patch component (UTC), e.g. "20260707". Used as
+ * the patch segment of the package version so each release is dated.
+ * @returns {string}
+ */
+function releaseDatePatch() {
+  const now = new Date();
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(now.getUTCDate()).padStart(2, "0");
+  return `${yyyy}${mm}${dd}`;
 }
 
 /**

--- a/deploy/createBaselineTypesPackages.js
+++ b/deploy/createBaselineTypesPackages.js
@@ -8,6 +8,7 @@
 
 import fs from "fs";
 import { fileURLToPath } from "url";
+import semver from "semver";
 import pkg from "prettier";
 import path from "path";
 const { format } = pkg;
@@ -151,7 +152,7 @@ async function updatePackageJSON(pkg, packagePath) {
   // The patch component is the release date (UTC, YYYYMMDD), so every publish is
   // stamped with the day it was cut — e.g. 1.0.20260707. The major and minor stay
   // fixed at 1.0; the date-based patch monotonically increases across releases.
-  packageJSON.version = `1.0.${releaseDatePatch()}`;
+  packageJSON.version = await datedVersion(packageJSON.name);
 
   fs.writeFileSync(
     pkgJSONPath,
@@ -161,6 +162,35 @@ async function updatePackageJSON(pkg, packagePath) {
   );
 
   return packageJSON;
+}
+
+/**
+ * The version for today's release: `1.0.<YYYYMMDD>` (UTC), e.g. `1.0.20260707`.
+ *
+ * Guards against a same-day double publish: npm rejects re-publishing an
+ * existing version, so if the dated version is not strictly greater than what is
+ * already on npm (i.e. another release already went out today), the patch is
+ * bumped one past the latest instead — a second same-day cut becomes
+ * `1.0.20260708`. The once-a-day common case keeps the plain dated version.
+ * @param {string} name
+ * @returns {Promise<string>}
+ */
+async function datedVersion(name) {
+  const version = `1.0.${releaseDatePatch()}`;
+  try {
+    const npmResponse = await fetch(`https://registry.npmjs.org/${name}`);
+    const latest = (await npmResponse.json())?.["dist-tags"]?.latest;
+    // Only bump when today's dated version wouldn't be a strict increase, i.e. a
+    // release already happened today (or the patch has drifted ahead of the date
+    // from a prior same-day burst).
+    if (typeof latest === "string" && !semver.gt(version, latest)) {
+      const [major, minor, patch] = latest.split(".");
+      return `${major}.${minor}.${Number(patch) + 1}`;
+    }
+  } catch {
+    // NOOP: package not published yet — the dated version is the first release.
+  }
+  return version;
 }
 
 /**

--- a/deploy/readmes/baseline-dom.md
+++ b/deploy/readmes/baseline-dom.md
@@ -63,8 +63,9 @@ Removing `"dom"` lets this package provide the global declarations instead.
 
 This project does not respect semantic versioning — the underlying spec data and
 Baseline computation change over time, and any update could add or remove types.
-The year in the package name is the stable axis; the version only tracks data
-refreshes.
+The year in the package name is the stable axis. The version's patch component is
+the release date (`1.0.YYYYMMDD`, e.g. `1.0.20260707`), so the version simply
+records the day each data refresh was cut.
 
 ## Deploy Metadata
 


### PR DESCRIPTION
## Summary

Changes the `@baseline-types/dom-<year>` version scheme from a per-release patch bump to a **date-based patch**: `1.0.<YYYYMMDD>` (e.g. `1.0.20260707`). The major/minor are fixed at `1.0` and the patch records the UTC day each data refresh was cut, so the version itself tells you how fresh the Baseline data is.

## Changes

- **`deploy/createBaselineTypesPackages.js`** — `updatePackageJSON` now sets the version via a new `datedVersion()` helper instead of fetching npm's `latest` and incrementing the patch by one.
- **Same-day double-publish guard** — npm rejects re-publishing an existing version, so two content-changing releases on the same UTC day would both compute `1.0.<YYYYMMDD>` and the second `npm publish` would fail. `datedVersion()` looks up the package's `latest` on npm and, when today's dated version isn't a strict increase, bumps the patch one past the latest instead (a second same-day cut becomes `1.0.20260708`). The common once-a-day case keeps the plain dated version, and the patch re-aligns with the date as soon as a clearly later day is cut.
- **`deploy/readmes/baseline-dom.md`** — the "SemVer" section (templated into each published package's README) now describes the `1.0.YYYYMMDD` scheme.
- **`CHANGELOG.md`** — note documenting the versioning-scheme change.

## Behavior

| latest on npm | → published | scenario |
|---|---|---|
| _(none)_ | `1.0.20260707` | first publish |
| `0.0.2` | `1.0.20260707` | migrating from old scheme |
| `1.0.20260630` | `1.0.20260707` | normal weekly release |
| `1.0.20260707` | `1.0.20260708` | same-day 2nd publish |
| `1.0.20260708` | `1.0.20260709` | same-day 3rd publish |
| `1.0.20260709` | `1.0.20260714` | later day — realigns to date |

## Testing

- `npx eslint --max-warnings 0 deploy/*.js scripts` — passes
- `npx tsc -p deploy/jsconfig.json` — passes
- Smoke-tested the `datedVersion()` decision logic across all scenarios in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1TnX5TYdeW2nBWnbkj2Nw

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TnX5TYdeW2nBWnbkj2Nw)_