### PR TITLE
Baseline cut: emit referentially-resurrected interfaces as type-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ for changes to the build pipeline itself.
 
 ## Unreleased
 
+- **Fix: interfaces kept only for referential closure no longer expose a
+  constructor.** When a cut removes an interface that is still referenced as a
+  *type* by a surviving API, the build resurrects it so the reference resolves.
+  Previously that resurrection restored the interface's full runtime object,
+  which let `new WebTransport()` (and other not-yet-Baseline constructors)
+  type-check in cuts predating the API — e.g. `@baseline-types/dom-2024`
+  emitted a usable `WebTransport` constructor even though WebTransport is
+  Baseline 2026. Such interfaces are now emitted as a type-only shell (no
+  `declare var`, so no constructor or statics); the type still resolves, but the
+  runtime object the cut can't vouch for is gone. Interfaces that clear the
+  Baseline bar on their own keep their constructor unchanged.
 - **New: moving-target packages `@baseline-types/dom-newly-available` and
   `@baseline-types/dom-widely-available`.** Alongside the frozen per-year cuts,
   these two packages track the latest Baseline state and advance as APIs qualify:

--- a/src/build/bcd/baseline.ts
+++ b/src/build/bcd/baseline.ts
@@ -350,6 +350,12 @@ export function manuallyReferencedValueTypes(
  * often carry references as raw signature strings, so those are matched
  * textually against removed names.
  *
+ * A resurrected interface is kept as a *type only*: the closure clears its
+ * interface-level `exposed: ""` marker (so the type is emitted) but marks it
+ * `noInterfaceObject` (so its runtime `declare var` — constructor and statics —
+ * is not). The API failed the Baseline bar; only references to its type need to
+ * resolve, and emitting the constructor would wrongly let `new X()` type-check.
+ *
  * Mutates and returns `removalData` (clears the interface-level `exposed: ""`
  * marker for resurrected interfaces while keeping their member-level removals).
  */
@@ -444,7 +450,18 @@ export function applyReferenceClosure(
   }
 
   for (const name of resurrected) {
+    // The interface failed the Baseline bar and is kept only so references to
+    // its *type* stay resolvable. Its runtime object is not Baseline-available,
+    // so suppress the `declare var X: { prototype: X; new(...): X }` emit (which
+    // would otherwise let `new WebTransport()` type-check in a cut predating
+    // WebTransport). `noInterfaceObject` is exactly "emit the type, not the
+    // runtime object"; setting it leaves the interface as a type-only shell.
+    // Guard against re-setting an already-[LegacyNoInterfaceObject] interface to
+    // avoid a redundant-merge warning.
     delete removalInterfaces[name].exposed;
+    if (!fullInterfaces[name]?.noInterfaceObject) {
+      removalInterfaces[name].noInterfaceObject = true;
+    }
   }
   return removalData;
 }


### PR DESCRIPTION
## Problem

`new WebTransport()` type-checks in Baseline cuts that predate WebTransport (Baseline 2026) — e.g. `@baseline-types/dom-2024`:

```ts
// dom-2024, before this change
interface WebTransport { }
declare var WebTransport: {
    prototype: WebTransport;
    new(url: string | URL, options?: WebTransportOptions): WebTransport;  // ← should not exist
};
```

## Cause

When a cut removes an interface that a *surviving* API still references as a **type**, `applyReferenceClosure` resurrects it so the reference resolves (the README's "referentially closed" guarantee). It did so by clearing the interface-level `exposed: ""` marker — which restored the interface's **entire runtime object**, including its constructor. The interface was kept for its *type*, but got its runtime `declare var` back too.

## Fix

Resurrected interfaces are now marked `noInterfaceObject`, which the emitter already treats as "emit the type, not the runtime object". The type still resolves for references; the `declare var` (constructor + statics) — which the cut can't vouch for — is dropped.

```ts
// dom-2024, after this change
interface WebTransport { }   // type still resolves; no runtime object

declare function get(): WebTransport;
const wt: WebTransport = get();          // ✓ ok
new WebTransport("https://example.com"); // ✗ TS2693: 'WebTransport' only refers to a type
```

Interfaces that clear the Baseline bar on their own are untouched and keep their constructor (verified against `dom-2026` and `dom-newly-available`).

## Verification

- **dom-2024** (not Baseline): type-only shell, `new WebTransport()` errors with `TS2693`
- **dom-2026 / newly-available** (Baseline): full `new(url, options)` constructor kept unchanged
- **Non-baseline build**: `node src/test.ts` → *All tests passed* (byte-identical to upstream; the closure only runs under a cut)
- `npm run lint` (eslint + `tsc`) and `unittests/index.js` pass

## Files

- `src/build/bcd/baseline.ts` — mark resurrected interfaces `noInterfaceObject` in `applyReferenceClosure`
- `CHANGELOG.md` — Unreleased entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019X6gt5FGrJuCfjjLEkr3nN)_