### PR TITLE
Baseline cut: don't resurrect patched-but-unreferenced interfaces (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ for changes to the build pipeline itself.
 
 ## Unreleased
 
+- **Fix: a cut no longer carries interfaces that nothing references.** The
+  referential-closure pass has a raw-text fallback that scans the manual input
+  files (`inputfiles/patches/*.kdl`, `addedTypes.jsonc`, `overridingTypes.jsonc`)
+  for mentions of a removed interface's name, to catch references hidden inside
+  raw signature strings. It used to match a removed interface's *own
+  declaration* — a patch that only *modifies* `WebTransport` mentions the name
+  in its record key, so `WebTransport` was resurrected even though no surviving
+  API used it as a type. Cuts like `@baseline-types/dom-2024` therefore emitted
+  a batch of interfaces they didn't need — the `WebTransport` family, the
+  `PaymentRequest` API and its dictionaries, `ScriptProcessorNode`,
+  `SharedWorker`, `PerformanceTiming`/`PerformanceNavigation`, and more — none
+  of which is Baseline in the cut or referenced by anything that is. The
+  fallback now looks only at string *values* with declaration identifiers
+  (record keys and `name` fields) stripped, so patching an interface no longer
+  counts as referencing it; genuine references in raw signature strings are
+  still caught.
+- **Fix: interfaces that fail the Baseline bar never expose a constructor,
+  even when re-exposed by an override.** A few interfaces fail the bar but are
+  deliberately re-exposed as a *type* by an `"exposed"` override (e.g.
+  `MIDIAccess`, `SourceBuffer`, which the overrides scope to `Window`). Their
+  `declare var` — the runtime constructor and statics — is now suppressed in
+  cuts where the API isn't Baseline-available, so `new MIDIAccess()` no longer
+  type-checks there; the type still resolves for references. This extends the
+  same type-only treatment already applied to interfaces kept purely for
+  referential closure (below) to the override-re-exposed case.
 - **Fix: interfaces kept only for referential closure no longer expose a
   constructor.** When a cut removes an interface that is still referenced as a
   *type* by a surviving API, the build resurrects it so the reference resolves.

--- a/src/build/bcd/baseline.ts
+++ b/src/build/bcd/baseline.ts
@@ -257,6 +257,43 @@ function escapeRegExp(value: string): string {
 }
 
 /**
+ * Collect the string leaves of the manual inputs for the raw-text reference
+ * fallback, EXCLUDING declaration identifiers. Two sources of a removed
+ * interface's *own* name are dropped so that merely patching an interface does
+ * not count as a reference to it:
+ *
+ * - Object keys (the record key, e.g. `interfaces.interface.WebTransport`) are
+ *   never string *values*, so recursing over values alone drops them naturally.
+ * - `name`-field values duplicate that record key on the entity itself, so they
+ *   are skipped explicitly.
+ *
+ * What survives is exactly the textual content the structured
+ * `collectTypeReferences` scan can't see — raw signature strings in
+ * `overrideSignatures`/`overrideType` (e.g. `"...): MathMLElement"`) — which is
+ * the only thing this fallback needs to catch.
+ */
+function collectManualReferenceStrings(value: unknown, out: string[]): void {
+  if (typeof value === "string") {
+    out.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectManualReferenceStrings(item, out);
+    }
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      if (key === "name") {
+        continue;
+      }
+      collectManualReferenceStrings(child, out);
+    }
+  }
+}
+
+/**
  * Value types (dictionaries/enums/typedefs/callback functions) are never
  * baseline-removed, but the per-scope emit only keeps the ones still reachable
  * from a surviving interface. One whose only remaining reference is a raw-string
@@ -356,8 +393,17 @@ export function manuallyReferencedValueTypes(
  * is not). The API failed the Baseline bar; only references to its type need to
  * resolve, and emitting the constructor would wrongly let `new X()` type-check.
  *
- * Mutates and returns `removalData` (clears the interface-level `exposed: ""`
- * marker for resurrected interfaces while keeping their member-level removals).
+ * The same `noInterfaceObject` marking is applied to *every* baseline-removed
+ * interface, not just resurrected ones. A removed interface can also re-enter
+ * the cut through a manual `exposed` override merged after removal (e.g.
+ * MIDIAccess/SourceBuffer, which overrides scope to `Window`); it still failed
+ * the Baseline bar, so its runtime object must be suppressed there too. For
+ * interfaces that simply stay removed the marker is inert — they are never
+ * emitted.
+ *
+ * Mutates and returns `removalData`: clears the interface-level `exposed: ""`
+ * marker for resurrected interfaces (keeping their member-level removals) and
+ * sets `noInterfaceObject` on every removed interface.
  */
 export function applyReferenceClosure(
   webidl: Browser.WebIdl,
@@ -425,11 +471,18 @@ export function applyReferenceClosure(
   }
 
   // Manual inputs merged after removal: structured references plus raw
-  // signature strings (e.g. "...): MathMLElement") matched by name.
+  // signature strings (e.g. "...): MathMLElement") matched by name. The text
+  // match sees only string *values* with declaration identifiers (record keys
+  // and `name` fields) stripped, so a patch that merely modifies an interface
+  // — mentioning its own name in the record key/`name` field — does not
+  // spuriously resurrect it. Joined with newlines so a name can't straddle two
+  // adjacent leaves and form a false `\b` match.
   for (const source of extraReferenceSources) {
     consider(collectTypeReferences(source));
   }
-  const manualText = JSON.stringify(extraReferenceSources);
+  const manualStrings: string[] = [];
+  collectManualReferenceStrings(extraReferenceSources, manualStrings);
+  const manualText = manualStrings.join("\n");
   for (const name of removedNames) {
     if (
       !resurrected.has(name) &&
@@ -449,19 +502,44 @@ export function applyReferenceClosure(
     }
   }
 
-  for (const name of resurrected) {
-    // The interface failed the Baseline bar and is kept only so references to
-    // its *type* stay resolvable. Its runtime object is not Baseline-available,
-    // so suppress the `declare var X: { prototype: X; new(...): X }` emit (which
-    // would otherwise let `new WebTransport()` type-check in a cut predating
-    // WebTransport). `noInterfaceObject` is exactly "emit the type, not the
-    // runtime object"; setting it leaves the interface as a type-only shell.
-    // Guard against re-setting an already-[LegacyNoInterfaceObject] interface to
-    // avoid a redundant-merge warning.
-    delete removalInterfaces[name].exposed;
-    if (!fullInterfaces[name]?.noInterfaceObject) {
+  // Interfaces whose runtime object a manual input already suppresses (e.g. the
+  // RTCIceCandidatePair override rolls it back toward a dictionary form). Skip
+  // them below so noInterfaceObject isn't merged true-onto-true, which warns.
+  const alreadyNoInterfaceObject = new Set<string>();
+  for (const source of extraReferenceSources) {
+    const interfaces = (source as Browser.WebIdl | undefined)?.interfaces
+      ?.interface;
+    for (const [name, entry] of Object.entries(interfaces ?? {})) {
+      if (entry?.noInterfaceObject) {
+        alreadyNoInterfaceObject.add(name);
+      }
+    }
+  }
+
+  // Suppress the runtime object of every baseline-removed interface. Whichever
+  // way it re-enters the cut — resurrected below for referential closure, or
+  // re-exposed by an `exposed` override merged after removal — it failed the
+  // Baseline bar, so its `declare var X: { prototype: X; new(...): X }` must not
+  // be emitted (that would let `new WebTransport()` / `new MIDIAccess()`
+  // type-check in a cut where the API isn't Baseline-available). Only references
+  // to the *type* need to resolve. `noInterfaceObject` is exactly "emit the
+  // type, not the runtime object". For interfaces that stay removed the marker
+  // is inert. Skip interfaces already flagged (by the full graph's
+  // [LegacyNoInterfaceObject] or a manual input) to avoid a redundant-merge
+  // warning.
+  for (const name of removedNames) {
+    if (
+      !fullInterfaces[name]?.noInterfaceObject &&
+      !alreadyNoInterfaceObject.has(name)
+    ) {
       removalInterfaces[name].noInterfaceObject = true;
     }
+  }
+  // Resurrected interfaces have no other path back into the cut, so clear their
+  // interface-level `exposed: ""` marker to emit them as a type-only shell.
+  // (Override-re-exposed interfaces get their exposure from the override merge.)
+  for (const name of resurrected) {
+    delete removalInterfaces[name].exposed;
   }
   return removalData;
 }


### PR DESCRIPTION
Fixes #12.

## Problem

`applyReferenceClosure`'s raw-text fallback scans the manual inputs (`inputfiles/patches/*.kdl`, `addedTypes.jsonc`, `overridingTypes.jsonc`) for a removed interface's name, to catch references hidden inside raw signature strings that the structured `collectTypeReferences` scan can't see. It stringified the whole input graph and regex-matched `\bName\b`, so it also matched a removed interface's **own declaration site** — a patch that merely *modifies* `WebTransport` mentions the name in its record key and `name` field, so `WebTransport` was resurrected into the cut even though nothing surviving references it as a type.

This turned out to be broader than the "handful of empty shells" the issue estimated: several spuriously-resurrected interfaces came back **full-bodied** (their members weren't individually baseline-removed), so `@baseline-types/dom-2024` carried the entire `PaymentRequest` API and its dictionaries, the WebTransport family, `ScriptProcessorNode`, `SharedWorker`, `PerformanceTiming`/`PerformanceNavigation`, and more — none Baseline in the cut, none referenced by anything that is.

## Changes

- **Text fallback ignores declaration identifiers.** Collect only the string *leaf values* of the manual inputs (`collectManualReferenceStrings`), skipping `name` fields — record keys are never values, so they drop out naturally. Patching an interface no longer counts as referencing it, while genuine references embedded in raw signature strings (`overrideSignatures` / `overrideType`, e.g. `"...): MathMLElement"`) are still matched.
- **No non-Baseline constructors, even via overrides.** A few interfaces fail the Baseline bar but are deliberately re-exposed as a *type* by an `"exposed"` override (`MIDIAccess`, `SourceBuffer`, scoped to `Window`). Previously the spurious match resurrected them, which *happened* to suppress their `declare var`; without that accident they'd emit a runtime constructor the cut can't vouch for. Now `noInterfaceObject` is marked on **every** baseline-removed interface, so whichever way one re-enters the cut — resurrection or an override — `new X()` can't type-check while the type still resolves. Interfaces a manual input already flags `noInterfaceObject` (`RTCIceCandidatePair`) are skipped to avoid a redundant-merge warning.

## Verification (against the real `BASELINE_TARGET=2024` build)

- **31 interfaces dropped** from the dom cut (WebTransport family, PaymentRequest API + dictionaries, `ScriptProcessorNode`, `SharedWorker`, `PerformanceTiming`/`Navigation`, `GPUPipelineError`, `MediaMetadata`, …).
- **No dangling references** in any scope — the Payment dictionaries remain declared in the worker scopes that genuinely use them (Payment Handler API). The dom and serviceworker cut libs **type-check clean** under `tsc`.
- The emitted **`declare var` set is identical to before** — the MIDI/SourceBuffer constructors were already absent (previously for the wrong reason); now they're absent by design.
- Build **redundant-merge warnings drop from 7 to 5** (removed artifacts of the old spurious resurrection; introduced none); `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014cgraj3CJtb6N7T3eiSTLT)_