### PR TITLE
Baseline cut: make removal authoritative over `exposed` overrides

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -239,6 +239,26 @@ async function emitDom() {
     }
   }
 
+  if (isBaselineCut) {
+    // Baseline removal is authoritative over a manual `exposed` override.
+    // A few non-Baseline interfaces carry an `exposed` override written for
+    // full-lib scope reasons (e.g. MIDIAccess/SourceBuffer, narrowed to
+    // `Window` because engines only ship them there). Merged after the removal
+    // data, that override overwrites the interface-level `exposed: ""` cut
+    // marker and re-exposes the interface's *type* into the cut even though
+    // nothing Baseline references it. applyReferenceClosure already cleared the
+    // marker for interfaces the surviving graph genuinely references (the
+    // `resurrected` set), so any interface still marked `exposed: ""` in
+    // removalData is both non-Baseline and unreferenced — re-assert its removal
+    // here, after every manual input has merged.
+    const removedInterfaces = removalData.interfaces?.interface ?? {};
+    for (const [interfaceName, entry] of Object.entries(removedInterfaces)) {
+      if (entry.exposed === "" && webidl.interfaces!.interface[interfaceName]) {
+        webidl.interfaces!.interface[interfaceName].exposed = "";
+      }
+    }
+  }
+
   const transferables = Object.values(
     webidl.interfaces?.interface ?? {},
   ).filter((i) => i.transferable);


### PR DESCRIPTION
## Background

Follow-up to #13. That PR made the **constructor** removal robust — `new MIDIAccess()` can't type-check whichever way a baseline-removed interface re-enters the cut. This closes the remaining gap it noted: a non-Baseline interface's **type** could still be nameable in the cut.

## Problem

A few non-Baseline interfaces carry a manual `exposed` override in `overridingTypes.jsonc` that exists only to narrow **full-lib** scope — e.g. `MIDIAccess`/`SourceBuffer`, restricted to `Window` because engines ship them on the main thread and not in workers. That override has nothing to do with Baseline.

But it merges *after* the baseline removal data (`merge(webidl, removalData)` → later `merge(webidl, overriddenItems)`), and `merge` is last-write-wins for scalars. So `exposed: "Window"` overwrote the interface's `exposed: ""` cut marker and re-exposed the interface's **type** into the Baseline cut, even though nothing Baseline references it. A scope-narrowing override ended up making a Baseline-membership decision it was never meant to make.

## Change

`applyReferenceClosure` already clears the removal marker for interfaces the surviving graph genuinely references (the `resurrected` set). So any interface still marked `exposed: ""` in `removalData` after the closure is **both non-Baseline and unreferenced**. Re-assert its interface-level removal after every manual input has merged, so a scope-narrowing override can no longer decide Baseline membership.

This is deliberately narrow: it re-asserts only the **interface-level** exposure removal, and only for interfaces the closure already proved unreferenced — so it can't create a dangling reference, and it leaves member-level removals (which must still yield to manual additions) untouched. Guarded by `isBaselineCut`, so the normal build path is unaffected.

The two re-entry paths are now cleanly separated:
- **referential closure** — resurrects a type-only shell when something surviving genuinely references it (kept);
- **`exposed` override** — can no longer pull a non-Baseline type back into the cut (fixed here).

## Verification (`BASELINE_TARGET=2024`)

- **12 unreferenced interfaces drop from the dom cut**: `MIDIAccess`/`MIDIInput`/`MIDIOutput` and their maps, the `SourceBuffer` family, and `RTCIceCandidatePair` — all non-Baseline, none referenced by anything that is. (The MIDI asymmetry is correct: `MIDIConnectionEvent`/`MIDIMessageEvent`/`MIDIPort` survive on their own merits.)
- **No interface reappears**; **worker cuts unchanged** (the overrides were `Window`-scoped).
- **No dangling references** — every dom cut variant (es5/es6/es2018, incl. iterable/asynciterable) type-checks clean under `tsc`.
- The **normal non-cut build is byte-identical** to the committed baselines.
- `npm run lint` passes; no new build warnings (the 3 "degrade to any" messages are pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4Tv6kZ77DRg6VRFQjHNCz)_