### PR TITLE
Refactor the Baseline cut machinery; drop value types forced by their own declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ for changes to the build pipeline itself.
 
 ## Unreleased
 
+- **Fix: a cut no longer force-emits value types that nothing references.**
+  Dictionaries, enums, and typedefs named in the manual input files are kept
+  in every scope of a cut so that references hidden inside raw signature
+  strings never dangle. That scan matched a value type's *own declaration
+  site* — merely patching a dictionary counted as referencing it — so cut
+  builds carried unreachable declarations: the WebAuthn
+  `PublicKeyCredential*`/`AuthenticationExtensions*` dictionaries and
+  `KeyboardEventInit`/`UIEventInit` in all worker scopes, `RequestInit` and
+  other fetch types in `audioworklet` (where `HeadersInit` degraded to a
+  dangling `type HeadersInit = any`), `TokenBinding`, and the
+  `URLPatternResult` family. The scan now uses the same
+  declaration-identifier-stripped matcher as the referential-closure pass
+  (introduced when fixing the interface-side twin of this bug, below), so
+  those declarations are dropped from every cut. Full (non-cut) builds are
+  unaffected.
 - **Fix: a cut no longer carries interfaces that nothing references.** The
   referential-closure pass has a raw-text fallback that scans the manual input
   files (`inputfiles/patches/*.kdl`, `addedTypes.jsonc`, `overridingTypes.jsonc`)

--- a/src/build.ts
+++ b/src/build.ts
@@ -13,6 +13,7 @@ import {
   applyReferenceClosure,
   isBaselineCut,
   manuallyReferencedValueTypes,
+  reassertBaselineRemovals,
 } from "./build/bcd/baseline.ts";
 import { getInterfaceElementMergeData } from "./build/webref/elements.ts";
 import { getInterfaceToEventMap } from "./build/webref/events.ts";
@@ -211,17 +212,24 @@ async function emitDom() {
   }
   webidl = merge(webidl, await getInterfaceElementMergeData());
 
+  // Manual input files merged into the graph below; a Baseline cut also scans
+  // them for references so the cut stays consistent with what they pull in.
+  const manualInputs = [addedItems, overriddenItems, patches];
+
   webidl = merge(webidl, getDeprecationData(webidl));
-  let removalData = getRemovalData(webidl);
+  const removalData = getRemovalData(webidl);
+  // Interfaces the Baseline cut removed and nothing surviving references;
+  // their removal is re-asserted after the manual inputs merge.
+  let baselineStillRemoved = new Set<string>();
   if (isBaselineCut) {
     // Keep the cut referentially closed: don't remove interfaces that surviving
     // APIs still reference, including types pulled in by the manual input files
     // that are merged below.
-    removalData = applyReferenceClosure(webidl, removalData, [
-      addedItems,
-      overriddenItems,
-      patches,
-    ]);
+    ({ stillRemoved: baselineStillRemoved } = applyReferenceClosure(
+      webidl,
+      removalData,
+      manualInputs,
+    ));
   }
   webidl = merge(webidl, removalData);
   webidl = merge(webidl, getDocsData(webidl));
@@ -240,23 +248,10 @@ async function emitDom() {
   }
 
   if (isBaselineCut) {
-    // Baseline removal is authoritative over a manual `exposed` override.
-    // A few non-Baseline interfaces carry an `exposed` override written for
-    // full-lib scope reasons (e.g. MIDIAccess/SourceBuffer, narrowed to
-    // `Window` because engines only ship them there). Merged after the removal
-    // data, that override overwrites the interface-level `exposed: ""` cut
-    // marker and re-exposes the interface's *type* into the cut even though
-    // nothing Baseline references it. applyReferenceClosure already cleared the
-    // marker for interfaces the surviving graph genuinely references (the
-    // `resurrected` set), so any interface still marked `exposed: ""` in
-    // removalData is both non-Baseline and unreferenced — re-assert its removal
-    // here, after every manual input has merged.
-    const removedInterfaces = removalData.interfaces?.interface ?? {};
-    for (const [interfaceName, entry] of Object.entries(removedInterfaces)) {
-      if (entry.exposed === "" && webidl.interfaces!.interface[interfaceName]) {
-        webidl.interfaces!.interface[interfaceName].exposed = "";
-      }
-    }
+    // A manual `exposed` override merged above may have overwritten the cut's
+    // interface-level `exposed: ""` marker; put it back. Why this is safe and
+    // necessary: see `reassertBaselineRemovals`.
+    reassertBaselineRemovals(webidl, baselineStillRemoved);
   }
 
   const transferables = Object.values(
@@ -325,11 +320,7 @@ async function emitDom() {
   // Baseline cut only: value types reachable only through raw-string manual
   // overrides, which the per-scope reachability pass can't otherwise see.
   const baselineKnownTypes = isBaselineCut
-    ? manuallyReferencedValueTypes(webidl, [
-        addedItems,
-        overriddenItems,
-        patches,
-      ])
+    ? manuallyReferencedValueTypes(webidl, manualInputs)
     : new Set<string>();
 
   for (const { outputFolder, compilerBehavior } of emitVariations) {

--- a/src/build/bcd.ts
+++ b/src/build/bcd.ts
@@ -39,20 +39,17 @@ function isSuitable(
   const forceAlive = parentKey
     ? forceKeepAlive[parentKey]?.includes(key)
     : !!forceKeepAlive[key];
-  // The upstream "supported by 2+ engines" rule.
-  const defaultSupported =
-    !!compat && hasMultipleImplementations(compat.support, prefix);
-  // With a Baseline cut requested, replace that rule with the target's Baseline
-  // bar -- but only when Baseline has data for the item. When it doesn't (no
-  // resolvable BCD key), defer to the upstream decision rather than
-  // unconditionally keeping: the cut must stay a subset of the full lib, never
-  // adding members the normal build drops (e.g. PerformanceEntry.id, which has
-  // no BCD entry and would otherwise clash with LargestContentfulPaint).
-  const supported = isBaselineCut
-    ? compatKeys && compatKeys.length > 0
-      ? isBaselineSuitable(compatKeys)
-      : defaultSupported
-    : defaultSupported;
+  // With a Baseline cut requested, replace the upstream "supported by 2+
+  // engines" rule with the target's Baseline bar -- but only when Baseline has
+  // data for the item (compatKeys is only ever non-empty under a cut). When it
+  // doesn't (no resolvable BCD key), defer to the upstream decision rather
+  // than unconditionally keeping: the cut must stay a subset of the full lib,
+  // never adding members the normal build drops (e.g. PerformanceEntry.id,
+  // which has no BCD entry and would otherwise clash with
+  // LargestContentfulPaint).
+  const supported = compatKeys?.length
+    ? isBaselineSuitable(compatKeys)
+    : !!compat && hasMultipleImplementations(compat.support, prefix);
   if (supported) {
     if (!isBaselineCut && forceAlive) {
       if (parentKey) {

--- a/src/build/bcd/baseline.ts
+++ b/src/build/bcd/baseline.ts
@@ -26,8 +26,10 @@ export type BaselineTarget =
   | { kind: "newly" }
   | { kind: "widely" };
 
-function parseBaselineTarget(): BaselineTarget | null {
-  const raw = process.env.BASELINE_TARGET;
+/** Parse a raw BASELINE_TARGET value. Pure; exported for tests. */
+export function parseBaselineTarget(
+  raw: string | undefined,
+): BaselineTarget | null {
   if (!raw) {
     return null;
   }
@@ -52,7 +54,9 @@ function parseBaselineTarget(): BaselineTarget | null {
   );
 }
 
-export const baselineTarget: BaselineTarget | null = parseBaselineTarget();
+export const baselineTarget: BaselineTarget | null = parseBaselineTarget(
+  process.env.BASELINE_TARGET,
+);
 
 /** True when any Baseline cut is active (year or moving). */
 export const isBaselineCut: boolean = baselineTarget !== null;

--- a/src/build/bcd/baseline.ts
+++ b/src/build/bcd/baseline.ts
@@ -74,8 +74,15 @@ function keyExists(key: string): boolean {
   }
 }
 
-/** BCD compat key for an interface/namespace itself, if BCD knows about it. */
-export function interfaceCompatKeys(name: string): string[] {
+/**
+ * BCD compat key for an interface/namespace itself, if BCD knows about it.
+ * Resolved only under a Baseline cut; returns undefined otherwise, so non-cut
+ * builds never touch compute-baseline and the mapper needs no cut check.
+ */
+export function interfaceCompatKeys(name: string): string[] | undefined {
+  if (!isBaselineCut) {
+    return undefined;
+  }
   const key = `api.${name}`;
   return keyExists(key) ? [key] : [];
 }
@@ -92,8 +99,34 @@ export function interfaceCompatKeys(name: string): string[] {
  *
  * Returns only keys that actually exist in BCD; computeBaseline throws on
  * unknown keys, so callers must check existing ones.
+ *
+ * Resolved only under a Baseline cut; returns undefined otherwise, so non-cut
+ * builds never touch compute-baseline and the mapper needs no cut check.
+ * When `fallback` is given and the member itself yields no keys, the fallback
+ * member is resolved instead (e.g. @@iterator falling back to values() — BCD
+ * rarely has an @@iterator entry).
  */
 export function memberCompatKeys(
+  interfaceName: string,
+  member: string,
+  node: Identifier | undefined,
+  fallback?: { member: string; node: Identifier | undefined },
+): string[] | undefined {
+  if (!isBaselineCut) {
+    return undefined;
+  }
+  const keys = resolveMemberCompatKeys(interfaceName, member, node);
+  if (keys.length === 0 && fallback) {
+    return resolveMemberCompatKeys(
+      interfaceName,
+      fallback.member,
+      fallback.node,
+    );
+  }
+  return keys;
+}
+
+function resolveMemberCompatKeys(
   interfaceName: string,
   member: string,
   node: Identifier | undefined,

--- a/src/build/bcd/baseline.ts
+++ b/src/build/bcd/baseline.ts
@@ -392,56 +392,55 @@ export function manuallyReferencedValueTypes(
   return forced;
 }
 
-/**
- * A pure Baseline-year cut is not referentially closed: an API kept for year N
- * may reference an interface that only reached Baseline later (e.g.
- * ImageBitmapRenderingContext, 2020, references ImageBitmap, 2021). Walk the
- * surviving graph and "resurrect" any baseline-removed interface that is still
- * referenced, so the emitted .d.ts stays valid. Only interfaces can be both
- * fully removed and referenced as a type (dictionaries/typedefs/enums/
- * callbacks/mixins are never baseline-removed, and namespaces aren't used as
- * types), so interfaces are the only resurrection targets.
- *
- * References come from several places: the surviving IDL graph, the
- * `webidl.events` map (event handler/map types), and the manual input files
- * (added/overriding/patch types) that are merged after removal. The latter
- * often carry references as raw signature strings, so those are matched
- * textually against removed names.
- *
- * A resurrected interface is kept as a *type only*: the closure clears its
- * interface-level `exposed: ""` marker (so the type is emitted) but marks it
- * `noInterfaceObject` (so its runtime `declare var` — constructor and statics —
- * is not). The API failed the Baseline bar; only references to its type need to
- * resolve, and emitting the constructor would wrongly let `new X()` type-check.
- *
- * The same `noInterfaceObject` marking is applied to *every* baseline-removed
- * interface, not just resurrected ones. A removed interface can also re-enter
- * the cut through a manual `exposed` override merged after removal (e.g.
- * MIDIAccess/SourceBuffer, which overrides scope to `Window`); it still failed
- * the Baseline bar, so its runtime object must be suppressed there too. For
- * interfaces that simply stay removed the marker is inert — they are never
- * emitted.
- *
- * Mutates and returns `removalData`: clears the interface-level `exposed: ""`
- * marker for resurrected interfaces (keeping their member-level removals) and
- * sets `noInterfaceObject` on every removed interface.
- */
-export function applyReferenceClosure(
-  webidl: Browser.WebIdl,
-  removalData: Browser.WebIdl,
-  extraReferenceSources: unknown[] = [],
-): Browser.WebIdl {
-  const removalInterfaces = removalData.interfaces?.interface ?? {};
+/** What the reference closure decided about the baseline-removed interfaces. */
+export interface BaselineRemovalPlan {
+  /**
+   * The removal data passed in, adjusted in place: interface-level
+   * `exposed: ""` markers cleared for resurrected interfaces (member-level
+   * removals kept), `noInterfaceObject` set on every removed interface.
+   */
+  removalData: Browser.WebIdl;
+  /**
+   * Baseline-removed interfaces kept as type-only shells because something
+   * surviving still references them as a type.
+   */
+  resurrected: Set<string>;
+  /**
+   * Baseline-removed interfaces that nothing surviving references. Their
+   * interface-level removal is authoritative: no later merge may re-expose
+   * them (see `reassertBaselineRemovals`).
+   */
+  stillRemoved: Set<string>;
+}
+
+/** Interfaces marked fully removed (`exposed: ""`) in the removal data. */
+function collectRemovedInterfaces(
+  removalInterfaces: Record<string, Browser.Interface>,
+): Set<string> {
   const removedNames = new Set<string>();
   for (const [name, entry] of Object.entries(removalInterfaces)) {
     if (entry.exposed === "") {
       removedNames.add(name);
     }
   }
-  if (removedNames.size === 0) {
-    return removalData;
-  }
+  return removedNames;
+}
 
+/**
+ * The subset of `removedNames` that the surviving graph still references as a
+ * type. References come from several places: the surviving IDL graph, the
+ * `webidl.events` map (event handler/map types), and the manual input files
+ * (added/overriding/patch types) that are merged after removal. The latter
+ * often carry references as raw signature strings, so those are matched
+ * textually against removed names.
+ */
+function computeResurrected(
+  webidl: Browser.WebIdl,
+  removalData: Browser.WebIdl,
+  removedNames: Set<string>,
+  extraReferenceSources: unknown[],
+): Set<string> {
+  const removalInterfaces = removalData.interfaces?.interface ?? {};
   const fullInterfaces = webidl.interfaces?.interface ?? {};
   const resurrected = new Set<string>();
   const seen = new Set<string>();
@@ -517,6 +516,29 @@ export function applyReferenceClosure(
     }
   }
 
+  return resurrected;
+}
+
+/**
+ * Suppress the runtime object of every baseline-removed interface. Whichever
+ * way it re-enters the cut — resurrected for referential closure, or
+ * re-exposed by an `exposed` override merged after removal — it failed the
+ * Baseline bar, so its `declare var X: { prototype: X; new(...): X }` must not
+ * be emitted (that would let `new WebTransport()` / `new MIDIAccess()`
+ * type-check in a cut where the API isn't Baseline-available). Only references
+ * to the *type* need to resolve. `noInterfaceObject` is exactly "emit the
+ * type, not the runtime object". For interfaces that stay removed the marker
+ * is inert. Skip interfaces already flagged (by the full graph's
+ * [LegacyNoInterfaceObject] or a manual input) to avoid a redundant-merge
+ * warning.
+ */
+function markRemovedInterfacesTypeOnly(
+  webidl: Browser.WebIdl,
+  removalInterfaces: Record<string, Browser.Interface>,
+  removedNames: Set<string>,
+  extraReferenceSources: unknown[],
+): void {
+  const fullInterfaces = webidl.interfaces?.interface ?? {};
   // Interfaces whose runtime object a manual input already suppresses (e.g. the
   // RTCIceCandidatePair override rolls it back toward a dictionary form). Skip
   // them below so noInterfaceObject isn't merged true-onto-true, which warns.
@@ -531,17 +553,6 @@ export function applyReferenceClosure(
     }
   }
 
-  // Suppress the runtime object of every baseline-removed interface. Whichever
-  // way it re-enters the cut — resurrected below for referential closure, or
-  // re-exposed by an `exposed` override merged after removal — it failed the
-  // Baseline bar, so its `declare var X: { prototype: X; new(...): X }` must not
-  // be emitted (that would let `new WebTransport()` / `new MIDIAccess()`
-  // type-check in a cut where the API isn't Baseline-available). Only references
-  // to the *type* need to resolve. `noInterfaceObject` is exactly "emit the
-  // type, not the runtime object". For interfaces that stay removed the marker
-  // is inert. Skip interfaces already flagged (by the full graph's
-  // [LegacyNoInterfaceObject] or a manual input) to avoid a redundant-merge
-  // warning.
   for (const name of removedNames) {
     if (
       !fullInterfaces[name]?.noInterfaceObject &&
@@ -550,11 +561,87 @@ export function applyReferenceClosure(
       removalInterfaces[name].noInterfaceObject = true;
     }
   }
+}
+
+/**
+ * A pure Baseline-year cut is not referentially closed: an API kept for year N
+ * may reference an interface that only reached Baseline later (e.g.
+ * ImageBitmapRenderingContext, 2020, references ImageBitmap, 2021). Walk the
+ * surviving graph and "resurrect" any baseline-removed interface that is still
+ * referenced, so the emitted .d.ts stays valid. Only interfaces can be both
+ * fully removed and referenced as a type (dictionaries/typedefs/enums/
+ * callbacks/mixins are never baseline-removed, and namespaces aren't used as
+ * types), so interfaces are the only resurrection targets.
+ *
+ * A resurrected interface is kept as a *type only*: the closure clears its
+ * interface-level `exposed: ""` marker (so the type is emitted) but marks it
+ * `noInterfaceObject` (so its runtime `declare var` — constructor and statics —
+ * is not). The API failed the Baseline bar; only references to its type need to
+ * resolve, and emitting the constructor would wrongly let `new X()` type-check.
+ * (Override-re-exposed interfaces get their exposure from the override merge
+ * instead; `markRemovedInterfacesTypeOnly` suppresses their runtime object all
+ * the same.)
+ *
+ * Mutates `removalData` and reports the decisions as explicit sets — see
+ * `BaselineRemovalPlan`.
+ */
+export function applyReferenceClosure(
+  webidl: Browser.WebIdl,
+  removalData: Browser.WebIdl,
+  extraReferenceSources: unknown[] = [],
+): BaselineRemovalPlan {
+  const removalInterfaces = removalData.interfaces?.interface ?? {};
+  const removedNames = collectRemovedInterfaces(removalInterfaces);
+  if (removedNames.size === 0) {
+    return { removalData, resurrected: new Set(), stillRemoved: new Set() };
+  }
+  const resurrected = computeResurrected(
+    webidl,
+    removalData,
+    removedNames,
+    extraReferenceSources,
+  );
+  markRemovedInterfacesTypeOnly(
+    webidl,
+    removalInterfaces,
+    removedNames,
+    extraReferenceSources,
+  );
   // Resurrected interfaces have no other path back into the cut, so clear their
   // interface-level `exposed: ""` marker to emit them as a type-only shell.
-  // (Override-re-exposed interfaces get their exposure from the override merge.)
   for (const name of resurrected) {
     delete removalInterfaces[name].exposed;
   }
-  return removalData;
+  const stillRemoved = new Set(
+    [...removedNames].filter((name) => !resurrected.has(name)),
+  );
+  return { removalData, resurrected, stillRemoved };
+}
+
+/**
+ * Re-assert the interface-level removals a Baseline cut decided on, after
+ * every manual input has merged. Baseline removal must be authoritative over
+ * a manual `exposed` override: a few non-Baseline interfaces carry an
+ * override written for full-lib scope reasons (e.g. MIDIAccess/SourceBuffer,
+ * narrowed to `Window` because engines only ship them there). Merged after
+ * the removal data, that override overwrites the interface-level
+ * `exposed: ""` cut marker and re-exposes the interface's *type* into the cut
+ * even though nothing Baseline references it.
+ *
+ * `stillRemoved` contains exactly the interfaces that are both non-Baseline
+ * and unreferenced (the reference closure already resurrected every
+ * referenced one), so re-asserting their removal cannot create a dangling
+ * reference. Member-level removals are left untouched — they must still yield
+ * to manual additions.
+ */
+export function reassertBaselineRemovals(
+  webidl: Browser.WebIdl,
+  stillRemoved: Set<string>,
+): void {
+  for (const name of stillRemoved) {
+    const iface = webidl.interfaces?.interface?.[name];
+    if (iface) {
+      iface.exposed = "";
+    }
+  }
 }

--- a/src/build/bcd/baseline.ts
+++ b/src/build/bcd/baseline.ts
@@ -258,9 +258,9 @@ function escapeRegExp(value: string): string {
 
 /**
  * Collect the string leaves of the manual inputs for the raw-text reference
- * fallback, EXCLUDING declaration identifiers. Two sources of a removed
- * interface's *own* name are dropped so that merely patching an interface does
- * not count as a reference to it:
+ * fallbacks, EXCLUDING declaration identifiers. Two sources of a declared
+ * entity's *own* name are dropped so that merely patching an entity does not
+ * count as a reference to it:
  *
  * - Object keys (the record key, e.g. `interfaces.interface.WebTransport`) are
  *   never string *values*, so recursing over values alone drops them naturally.
@@ -270,7 +270,7 @@ function escapeRegExp(value: string): string {
  * What survives is exactly the textual content the structured
  * `collectTypeReferences` scan can't see — raw signature strings in
  * `overrideSignatures`/`overrideType` (e.g. `"...): MathMLElement"`) — which is
- * the only thing this fallback needs to catch.
+ * the only thing these fallbacks need to catch.
  */
 function collectManualReferenceStrings(value: unknown, out: string[]): void {
   if (typeof value === "string") {
@@ -294,6 +294,21 @@ function collectManualReferenceStrings(value: unknown, out: string[]): void {
 }
 
 /**
+ * Word-boundary name matcher over the manual inputs' reference text (string
+ * leaf values, declaration identifiers excluded — see
+ * `collectManualReferenceStrings`). Leaves are joined with newlines so a name
+ * can't straddle two adjacent leaves and form a false `\b` match. Shared by
+ * both raw-text fallbacks so they can't drift apart in what counts as a
+ * reference.
+ */
+function manualReferenceMatcher(sources: unknown[]): (name: string) => boolean {
+  const strings: string[] = [];
+  collectManualReferenceStrings(sources, strings);
+  const text = strings.join("\n");
+  return (name) => new RegExp(`\\b${escapeRegExp(name)}\\b`).test(text);
+}
+
+/**
  * Value types (dictionaries/enums/typedefs/callback functions) are never
  * baseline-removed, but the per-scope emit only keeps the ones still reachable
  * from a surviving interface. One whose only remaining reference is a raw-string
@@ -305,12 +320,18 @@ function collectManualReferenceStrings(value: unknown, out: string[]): void {
  * Excludes base types (ArrayBufferView) and names that also have a nominal
  * declaration — interface/callback-interface/mixin (EventListener) — since
  * forcing a same-named value type would emit a duplicate declaration.
+ *
+ * Only the manual inputs' string *leaf values* are scanned (via
+ * `manualReferenceMatcher`), never declaration identifiers — a value type
+ * that is merely patched is not thereby referenced. Structured references
+ * carried by the manual inputs need no forcing: the inputs are merged into
+ * the graph before emit, so the per-scope reachability pass sees them.
  */
 export function manuallyReferencedValueTypes(
   webidl: Browser.WebIdl,
   manualInputs: unknown[],
 ): Set<string> {
-  const text = JSON.stringify(manualInputs);
+  const isManuallyReferenced = manualReferenceMatcher(manualInputs);
   // Keyed by the emitted `.name`, not the record key, since a patch can rename a
   // type (e.g. enum ClientType -> ClientTypes) and references use the new name.
   const named = (record: Record<string, { name: string }> | undefined) =>
@@ -357,7 +378,7 @@ export function manuallyReferencedValueTypes(
     if (
       !baseTypeConversionMap.has(name) &&
       !nominal.has(name) &&
-      new RegExp(`\\b${escapeRegExp(name)}\\b`).test(text)
+      isManuallyReferenced(name)
     ) {
       add(name);
     }
@@ -472,22 +493,16 @@ export function applyReferenceClosure(
 
   // Manual inputs merged after removal: structured references plus raw
   // signature strings (e.g. "...): MathMLElement") matched by name. The text
-  // match sees only string *values* with declaration identifiers (record keys
-  // and `name` fields) stripped, so a patch that merely modifies an interface
-  // — mentioning its own name in the record key/`name` field — does not
-  // spuriously resurrect it. Joined with newlines so a name can't straddle two
-  // adjacent leaves and form a false `\b` match.
+  // match sees only string *values* with declaration identifiers stripped
+  // (see `manualReferenceMatcher`), so a patch that merely modifies an
+  // interface — mentioning its own name in the record key/`name` field —
+  // does not spuriously resurrect it.
   for (const source of extraReferenceSources) {
     consider(collectTypeReferences(source));
   }
-  const manualStrings: string[] = [];
-  collectManualReferenceStrings(extraReferenceSources, manualStrings);
-  const manualText = manualStrings.join("\n");
+  const isManuallyReferenced = manualReferenceMatcher(extraReferenceSources);
   for (const name of removedNames) {
-    if (
-      !resurrected.has(name) &&
-      new RegExp(`\\b${escapeRegExp(name)}\\b`).test(manualText)
-    ) {
+    if (!resurrected.has(name) && isManuallyReferenced(name)) {
       resurrect(name);
     }
   }

--- a/src/build/bcd/mapper.ts
+++ b/src/build/bcd/mapper.ts
@@ -9,11 +9,7 @@ import type * as Browser from "../types.ts";
 import { filterMapRecord, isEmptyRecord } from "../utils/record.ts";
 import { mapDefined } from "../helpers.ts";
 import { hasStableImplementation } from "./stable.ts";
-import {
-  isBaselineCut,
-  interfaceCompatKeys,
-  memberCompatKeys,
-} from "./baseline.ts";
+import { interfaceCompatKeys, memberCompatKeys } from "./baseline.ts";
 
 interface DataToMap {
   key: string;
@@ -76,7 +72,7 @@ function mapInterfaceLike(
     key: name,
     compat: intCompat,
     mixin: !!i.mixin,
-    compatKeys: isBaselineCut ? interfaceCompatKeys(name) : undefined,
+    compatKeys: interfaceCompatKeys(name),
   });
   if (!data) {
     if (mapped) {
@@ -93,9 +89,7 @@ function mapInterfaceLike(
       parentKey: name,
       compat,
       mixin: !!i.mixin,
-      compatKeys: isBaselineCut
-        ? memberCompatKeys(name, key, data[key])
-        : undefined,
+      compatKeys: memberCompatKeys(name, key, data[key]),
     });
   };
 
@@ -115,25 +109,17 @@ function mapInterfaceLike(
     const iteratorCompat = mergeCompatStatements(
       data[iteratorKey] ?? data["values"],
     );
-    let iteratorCompatKeys: string[] | undefined;
-    if (isBaselineCut) {
-      // BCD rarely has an @@iterator entry; fall back to the iterable method
-      // (values()) the same way the compat lookup above does.
-      iteratorCompatKeys = memberCompatKeys(
-        name,
-        iteratorKey,
-        data[iteratorKey],
-      );
-      if (!iteratorCompatKeys.length) {
-        iteratorCompatKeys = memberCompatKeys(name, "values", data["values"]);
-      }
-    }
     const iteratorMapped = mapper({
       key: iteratorKey,
       parentKey: name,
       compat: iteratorCompat,
       mixin: !!i.mixin,
-      compatKeys: iteratorCompatKeys,
+      // Fall back to the iterable method (values()) the same way the compat
+      // lookup above does.
+      compatKeys: memberCompatKeys(name, iteratorKey, data[iteratorKey], {
+        member: "values",
+        node: data["values"],
+      }),
     });
     if (iteratorMapped !== undefined) {
       result.iterator = iteratorMapped;

--- a/unittests/baseline.js
+++ b/unittests/baseline.js
@@ -1,0 +1,229 @@
+// Unit tests for the Baseline cut machinery (src/build/bcd/baseline.ts).
+// These run WITHOUT BASELINE_TARGET set: the functions under test are pure
+// graph logic that doesn't consult the active target, plus the target parser
+// itself. Each fixture encodes a bug the cut has actually had (see PRs #11,
+// #13, #14) so the fix can't silently regress.
+import assert from "node:assert/strict";
+import {
+  applyReferenceClosure,
+  interfaceCompatKeys,
+  manuallyReferencedValueTypes,
+  memberCompatKeys,
+  parseBaselineTarget,
+  reassertBaselineRemovals,
+} from "../src/build/bcd/baseline.ts";
+
+// parseBaselineTarget: the three target forms, and rejection of everything else.
+{
+  assert.equal(parseBaselineTarget(undefined), null);
+  assert.equal(parseBaselineTarget(""), null);
+  assert.deepEqual(parseBaselineTarget("2024"), { kind: "year", year: 2024 });
+  assert.deepEqual(parseBaselineTarget("newly-available"), { kind: "newly" });
+  assert.deepEqual(parseBaselineTarget("widely-available"), {
+    kind: "widely",
+  });
+  assert.throws(() => parseBaselineTarget("1999"), /Invalid BASELINE_TARGET/);
+  assert.throws(() => parseBaselineTarget("20244"), /Invalid BASELINE_TARGET/);
+  assert.throws(() => parseBaselineTarget("widely"), /Invalid BASELINE_TARGET/);
+}
+
+// Compat-key resolvers are inert without an active cut (BASELINE_TARGET unset
+// in this process), so the mapper can call them unconditionally.
+{
+  assert.equal(interfaceCompatKeys("AbortController"), undefined);
+  assert.equal(memberCompatKeys("AbortController", "abort", {}), undefined);
+}
+
+// applyReferenceClosure on a small graph exercising every decision path:
+// - RefTarget    removed, referenced by a *surviving* member       -> resurrected
+// - ChainedRef   removed, referenced only by RefTarget's own member -> resurrected (fixpoint)
+// - RawStringRef removed, referenced only inside a raw override
+//                signature string in the manual inputs              -> resurrected
+// - DroppedRef   removed, referenced only by a member that is
+//                itself baseline-removed                            -> stays removed
+// - PatchedOnly  removed, its name appears in the manual inputs
+//                only as a declaration (record key + name field)    -> stays removed (#13)
+const makeGraph = () => ({
+  webidl: {
+    interfaces: {
+      interface: {
+        Keeper: {
+          name: "Keeper",
+          exposed: "Window",
+          properties: {
+            property: {
+              uses: { name: "uses", type: "RefTarget" },
+              gone: { name: "gone", type: "DroppedRef" },
+            },
+          },
+        },
+        RefTarget: {
+          name: "RefTarget",
+          exposed: "Window",
+          properties: {
+            property: {
+              chained: { name: "chained", type: "ChainedRef" },
+            },
+          },
+        },
+        ChainedRef: { name: "ChainedRef", exposed: "Window" },
+        RawStringRef: { name: "RawStringRef", exposed: "Window" },
+        DroppedRef: { name: "DroppedRef", exposed: "Window" },
+        PatchedOnly: { name: "PatchedOnly", exposed: "Window" },
+      },
+    },
+  },
+  removalData: {
+    interfaces: {
+      interface: {
+        Keeper: {
+          name: "Keeper",
+          properties: {
+            property: { gone: { exposed: "" } },
+          },
+        },
+        RefTarget: { name: "RefTarget", exposed: "" },
+        ChainedRef: { name: "ChainedRef", exposed: "" },
+        RawStringRef: { name: "RawStringRef", exposed: "" },
+        DroppedRef: { name: "DroppedRef", exposed: "" },
+        PatchedOnly: { name: "PatchedOnly", exposed: "" },
+      },
+    },
+  },
+  manualInputs: [
+    {
+      interfaces: {
+        interface: {
+          Keeper: {
+            name: "Keeper",
+            methods: {
+              method: {
+                make: {
+                  name: "make",
+                  overrideSignatures: ["make(): RawStringRef"],
+                },
+              },
+            },
+          },
+          PatchedOnly: { name: "PatchedOnly", deprecated: 1 },
+        },
+      },
+    },
+  ],
+});
+
+{
+  const { webidl, removalData, manualInputs } = makeGraph();
+  const plan = applyReferenceClosure(webidl, removalData, manualInputs);
+  const entries = plan.removalData.interfaces.interface;
+
+  assert.deepEqual(
+    [...plan.resurrected].sort(),
+    ["ChainedRef", "RawStringRef", "RefTarget"],
+    "surviving/raw-string/fixpoint references resurrect",
+  );
+  assert.deepEqual(
+    [...plan.stillRemoved].sort(),
+    ["DroppedRef", "PatchedOnly"],
+    "removed-member references and patch declaration sites do not resurrect",
+  );
+
+  // Resurrected interfaces come back as type-only shells (#11): removal
+  // marker cleared, runtime object suppressed.
+  for (const name of plan.resurrected) {
+    assert.equal(entries[name].exposed, undefined, `${name} re-exposed`);
+    assert.equal(entries[name].noInterfaceObject, true, `${name} type-only`);
+  }
+  // Every baseline-removed interface has its runtime object suppressed, even
+  // ones that stay removed — an `exposed` override may re-expose their type
+  // later, and the constructor must not come along (#13).
+  for (const name of plan.stillRemoved) {
+    assert.equal(entries[name].exposed, "", `${name} stays removed`);
+    assert.equal(entries[name].noInterfaceObject, true, `${name} type-only`);
+  }
+  // Member-level removals survive resurrection untouched.
+  assert.equal(entries.Keeper.properties.property.gone.exposed, "");
+}
+
+// reassertBaselineRemovals (#14): a manual `exposed` override merged after the
+// removal data must not decide Baseline membership. Only the interfaces the
+// closure proved unreferenced are re-removed.
+{
+  const { webidl, removalData, manualInputs } = makeGraph();
+  const plan = applyReferenceClosure(webidl, removalData, manualInputs);
+  // Simulate `merge(webidl, overriddenItems)` overwriting cut markers.
+  webidl.interfaces.interface.DroppedRef.exposed = "Window";
+  webidl.interfaces.interface.RefTarget.exposed = "Window";
+  reassertBaselineRemovals(webidl, plan.stillRemoved);
+  assert.equal(
+    webidl.interfaces.interface.DroppedRef.exposed,
+    "",
+    "unreferenced removal is authoritative over the override",
+  );
+  assert.equal(
+    webidl.interfaces.interface.RefTarget.exposed,
+    "Window",
+    "resurrected interfaces are not re-removed",
+  );
+}
+
+// manuallyReferencedValueTypes: value types are forced only when a manual
+// input genuinely references them in a string value — never because they are
+// merely declared/patched there (the value-type twin of #13) — and the forced
+// set is closed under the value types' own references.
+{
+  const webidl = {
+    interfaces: {
+      interface: {
+        SameName: { name: "SameName", exposed: "Window" },
+      },
+    },
+    dictionaries: {
+      dictionary: {
+        ForcedDict: {
+          name: "ForcedDict",
+          members: {
+            member: { parent: { name: "parent", type: "ParentDict" } },
+          },
+        },
+        ParentDict: { name: "ParentDict", members: { member: {} } },
+        PatchedDict: { name: "PatchedDict", members: { member: {} } },
+      },
+    },
+    enums: { enum: {} },
+    typedefs: { typedef: [{ name: "SameName", type: "number" }] },
+  };
+  const manualInputs = [
+    {
+      interfaces: {
+        interface: {
+          X: {
+            name: "X",
+            methods: {
+              method: {
+                m: {
+                  name: "m",
+                  // References ForcedDict and SameName only via raw text.
+                  overrideSignatures: ["m(init: ForcedDict): SameName"],
+                },
+              },
+            },
+          },
+        },
+      },
+      dictionaries: {
+        // A patch that merely modifies PatchedDict: declaration site only.
+        dictionary: { PatchedDict: { name: "PatchedDict", deprecated: 1 } },
+      },
+    },
+  ];
+  const forced = manuallyReferencedValueTypes(webidl, manualInputs);
+  assert.deepEqual(
+    [...forced].sort(),
+    ["ForcedDict", "ParentDict"],
+    "raw-string reference forces the type and closes over its own references; " +
+      "patched-only and nominal-named types stay out",
+  );
+}
+
+console.log("baseline unit tests passed");

--- a/unittests/index.js
+++ b/unittests/index.js
@@ -1,6 +1,8 @@
 import { execSync } from "child_process";
 import { readdir } from "fs/promises";
 
+await import("./baseline.js");
+
 for (const filename of await readdir(new URL("files/", import.meta.url))) {
   if (filename.endsWith(".ts")) {
     execSync(`npx tsc generated/dom.generated.d.ts unittests/files/${filename} --target es2020 --lib es2020 --types --noEmit --ignoreConfig`, {


### PR DESCRIPTION
Follow-up to the review of the Baseline filtering logic after #11, #13, and #14. All three fixes were bugs in the same mechanism — the in-band `exposed: ""` cut marker, merge order, and the raw-text reference fallback — so this refactor makes that mechanism explicit, deduplicates it, and pins it down with regression tests. Four commits, meant to be reviewed one at a time.

## 1. Fix: don't force value types that are merely patched (behavior change)

`manuallyReferencedValueTypes` scanned `JSON.stringify(manualInputs)`, so a value type's *own declaration site* (record key / `name` field) counted as a reference — the exact bug shape #13 fixed for interface resurrection, still present in the second text scan. 23 of the 47 value types declared in the manual inputs matched only via their declaration.

Both raw-text fallbacks now share one matcher (`manualReferenceMatcher`: string leaf values with declaration identifiers stripped, word-boundary matched), so they can't drift apart again. Cut builds drop the unreachable declarations:

- the WebAuthn `PublicKeyCredential*`/`AuthenticationExtensions*` dictionaries and `KeyboardEventInit`/`UIEventInit` in **all worker scopes**
- fetch types (`RequestInit`, `BodyInit`, …) in **audioworklet** — including a literally dangling `type HeadersInit = any` that the spurious forcing itself created (its "degraded unknown type" build warning disappears)
- `TokenBinding` and the `URLPatternResult` family

The diff against the previous 2024 cut is **strictly removals**, and every variant of the 2024 and newly-available cuts type-checks clean under `tsc`. Full (non-cut) builds are byte-identical.

## 2. The closure reports decisions as explicit sets

`applyReferenceClosure` communicated through mutation alone: the `resurrected` set never left the function, and the invariant #14 depends on ("any entry still marked `exposed: ''` afterwards is non-Baseline **and** unreferenced") existed only as a comment that `build.ts` re-derived by re-scanning `removalData`.

- The 130-line closure is split into named steps (`collectRemovedInterfaces`, `computeResurrected`, `markRemovedInterfacesTypeOnly`) and returns a `BaselineRemovalPlan { removalData, resurrected, stillRemoved }`.
- The post-merge re-assertion loop (#14) moves from `build.ts` into `baseline.ts` as `reassertBaselineRemovals(webidl, stillRemoved)`, consuming the explicit set.
- The manual-inputs list is bound once in `build.ts` instead of repeated per call site.

## 3. The cut gate lives in the compat-key resolvers

`interfaceCompatKeys`/`memberCompatKeys` return `undefined` themselves when no `BASELINE_TARGET` cut is active, so `mapper.ts` drops its three `isBaselineCut ? … : undefined` wrappers (and the import). `memberCompatKeys` takes an optional fallback member, absorbing the `@@iterator` → `values()` fallback `mapper.ts` duplicated in eight lines next to the equivalent compat lookup. `isSuitable`'s nested ternary in `bcd.ts` flattens to a single conditional.

Deliberately **not** done: restructuring `mergeCompatStatements` — it's upstream code, and keeping the fork's diff small in upstream files matters for the weekly refreshes. This commit shrinks that diff.

## 4. Pure target parser + regression tests for #11/#13/#14

`parseBaselineTarget(raw)` no longer reads `process.env` inside, making it testable; the env read stays a one-liner at the module edge. New `unittests/baseline.js` (wired into `unittests/index.js`) covers the pure parts of the machinery with small fixtures:

- target parsing (all three forms, invalid values rejected)
- compat-key resolvers are inert without an active cut
- `applyReferenceClosure`: every decision path on one graph — surviving reference resurrects, fixpoint chain resurrects, raw-string override reference resurrects, removed-member reference does not, a patch's own declaration site does not (#13); resurrected interfaces are type-only shells and stay-removed interfaces also carry `noInterfaceObject` (#11)
- `reassertBaselineRemovals`: an `exposed` override can't re-expose an unreferenced removed interface and can't touch resurrected ones (#14)
- `manuallyReferencedValueTypes`: raw-string references force a value type and close over its own references; patched-only and nominal-named types stay out

Mutation-checked: re-introducing the commit-1 bug makes the suite fail on exactly the expected assertion.

## Verification

- **Non-cut build**: byte-identical to the committed baselines at every commit (`node src/test.ts` → *All tests passed*)
- **`BASELINE_TARGET=2024`**: commit 1's diff is strictly removals; commits 2–4 are byte-identical to commit 1's output, build warnings included
- **Type-checking**: all 60 generated 2024-cut files (5 scopes × 4 TS versions × 3 iterator variants) and all newly-available scopes pass `tsc --noEmit`
- `npm test` (build + lint + baseline compare + unittests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cGb1ixrumZwLpKPFB6XUo

---
_Generated by [Claude Code](https://claude.ai/code/session_012cGb1ixrumZwLpKPFB6XUo)_